### PR TITLE
Add htmlToJson converter script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,15 @@ This contains everything you need to run your app locally.
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Convert HTML to JSON
+
+Use the `htmlToJson` script to quickly convert an HTML file to a JSON representation.
+
+```bash
+# Read HTML from a file
+node --loader ts-node/esm scripts/htmlToJson.ts path/to/file.html > output.json
+
+# Or pipe HTML directly
+cat index.html | node --loader ts-node/esm scripts/htmlToJson.ts > output.json
+```

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@google/genai": "^1.4.0",
+    "htmlparser2": "^10.0.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "@google/genai": "^1.4.0"
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
+    "ts-node": "^10.9.2",
     "typescript": "~5.7.2",
     "vite": "^6.2.0"
   }

--- a/scripts/htmlToJson.ts
+++ b/scripts/htmlToJson.ts
@@ -1,0 +1,46 @@
+import * as fs from 'fs';
+import { parseDocument } from 'htmlparser2';
+import { Element, DataNode, Node } from 'domhandler';
+
+function nodeToJson(node: Node): any {
+  switch (node.type) {
+    case 'tag':
+    case 'script':
+    case 'style':
+      const elem = node as Element;
+      return {
+        type: node.type,
+        name: elem.name,
+        attribs: elem.attribs,
+        children: elem.children.map(child => nodeToJson(child))
+      };
+    case 'text':
+      return (node as DataNode).data;
+    default:
+      return { type: node.type };
+  }
+}
+
+async function main() {
+  let html = '';
+  if (process.argv[2]) {
+    html = fs.readFileSync(process.argv[2], 'utf8');
+  } else {
+    html = await new Promise<string>((resolve, reject) => {
+      let data = '';
+      process.stdin.setEncoding('utf8');
+      process.stdin.on('data', chunk => data += chunk);
+      process.stdin.on('end', () => resolve(data));
+      process.stdin.on('error', reject);
+    });
+  }
+
+  const dom = parseDocument(html);
+  const json = dom.children.map(node => nodeToJson(node));
+  console.log(JSON.stringify(json, null, 2));
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `htmlToJson.ts` script to convert HTML to JSON
- document converter usage in README
- add `htmlparser2` and `ts-node` deps

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685916d5b8fc832991a17182c93e55ed

## Summary by Sourcery

Add a CLI script to convert HTML to JSON, document its usage, and include the required dependencies.

New Features:
- Introduce `htmlToJson.ts` script to parse HTML input (file or stdin) into a JSON structure

Enhancements:
- Add `htmlparser2` and `ts-node` dependencies for the HTML-to-JSON converter

Documentation:
- Document the HTML-to-JSON converter usage in the README