### PR TITLE
Add htmlToJson converter script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use the `htmlToJson` script to quickly convert an HTML file to a JSON representa
 
 ```bash
 # Read HTML from a file
-node --loader ts-node/esm scripts/htmlToJson.ts path/to/file.html > output.json
+npm run html-to-json -- path/to/file.html > output.json
 
 # Or pipe HTML directly
 cat index.html | npm run html-to-json > output.json

--- a/README.md
+++ b/README.md
@@ -12,3 +12,15 @@ This contains everything you need to run your app locally.
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Convert HTML to JSON
+
+Use the `htmlToJson` script to quickly convert an HTML file to a JSON representation.
+
+```bash
+# Read HTML from a file
+node --loader ts-node/esm scripts/htmlToJson.ts path/to/file.html > output.json
+
+# Or pipe HTML directly
+cat index.html | node --loader ts-node/esm scripts/htmlToJson.ts > output.json
+```

--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ Use the `htmlToJson` script to quickly convert an HTML file to a JSON representa
 node --loader ts-node/esm scripts/htmlToJson.ts path/to/file.html > output.json
 
 # Or pipe HTML directly
-cat index.html | node --loader ts-node/esm scripts/htmlToJson.ts > output.json
+cat index.html | npm run html-to-json > output.json
 ```

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@google/genai": "^1.4.0",
+    "htmlparser2": "^10.0.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "@google/genai": "^1.4.0"
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
+    "ts-node": "^10.9.2",
     "typescript": "~5.7.2",
     "vite": "^6.2.0"
   }

--- a/scripts/htmlToJson.ts
+++ b/scripts/htmlToJson.ts
@@ -1,0 +1,46 @@
+import * as fs from 'fs';
+import { parseDocument } from 'htmlparser2';
+import { Element, DataNode, Node } from 'domhandler';
+
+function nodeToJson(node: Node): any {
+  switch (node.type) {
+    case 'tag':
+    case 'script':
+    case 'style':
+      const elem = node as Element;
+      return {
+        type: node.type,
+        name: elem.name,
+        attribs: elem.attribs,
+        children: elem.children.map(child => nodeToJson(child))
+      };
+    case 'text':
+      return (node as DataNode).data;
+    default:
+      return { type: node.type };
+  }
+}
+
+async function main() {
+  let html = '';
+  if (process.argv[2]) {
+    html = fs.readFileSync(process.argv[2], 'utf8');
+  } else {
+    html = await new Promise<string>((resolve, reject) => {
+      let data = '';
+      process.stdin.setEncoding('utf8');
+      process.stdin.on('data', chunk => data += chunk);
+      process.stdin.on('end', () => resolve(data));
+      process.stdin.on('error', reject);
+    });
+  }
+
+  const dom = parseDocument(html);
+  const json = dom.children.map(node => nodeToJson(node));
+  console.log(JSON.stringify(json, null, 2));
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/htmlToJson.ts
+++ b/scripts/htmlToJson.ts
@@ -24,7 +24,7 @@ function nodeToJson(node: Node): any {
 async function main() {
   let html = '';
   if (process.argv[2]) {
-    html = fs.readFileSync(process.argv[2], 'utf8');
+    html = await fs.readFile(process.argv[2], 'utf8');
   } else {
     html = await new Promise<string>((resolve, reject) => {
       let data = '';

--- a/scripts/htmlToJson.ts
+++ b/scripts/htmlToJson.ts
@@ -15,7 +15,7 @@ function nodeToJson(node: Node): any {
         children: elem.children.map(child => nodeToJson(child))
       };
     case 'text':
-      return (node as DataNode).data;
+      return { type: 'text', data: (node as DataNode).data };
     default:
       return { type: node.type };
   }


### PR DESCRIPTION
## Summary
- add `htmlToJson.ts` script to convert HTML to JSON
- document converter usage in README
- add `htmlparser2` and `ts-node` deps

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685916d5b8fc832991a17182c93e55ed

## Summary by Sourcery

Add a new CLI script to convert HTML files or piped HTML input into a JSON representation, including necessary dependencies and usage documentation.

New Features:
- Introduce `htmlToJson` script to parse HTML into JSON format via file or stdin

Build:
- Add `htmlparser2` and `ts-node` dependencies required by the converter script

Documentation:
- Document `htmlToJson` usage in the README with examples for file-based and piped input